### PR TITLE
Feature: add site contributors to home page

### DIFF
--- a/.vitepress/theme/components/HomePage.vue
+++ b/.vitepress/theme/components/HomePage.vue
@@ -69,6 +69,7 @@ const fetchNewContributors = async (now: number) => {
   const repos = [
     { owner: "gamedig", repo: "rust-gamedig" },
     { owner: "gamedig", repo: "node-gamedig" },
+    { owner: "gamedig", repo: "gamedig.github.io" },
   ];
 
   let contributionsMap = new Map();


### PR DESCRIPTION
This adds site contributors dynamically to the home page. This is stored within local cache for 24 hours on user side. so it may take up to that time for users to see it but they can always clear cache.